### PR TITLE
Bug 1181153: update to use the new treestatus API [DO NOT LAND]

### DIFF
--- a/treestat@roach.at/content/TreeStatOverlay.js
+++ b/treestat@roach.at/content/TreeStatOverlay.js
@@ -60,7 +60,7 @@ var TreeStatOverlay = {
       var bottomspacer = document.createElement("spacer");
       image.setAttribute("tooltiptext",this.active[item]);
       image.addEventListener("click", this.makeOnClick(
-          this.prefs.getCharPref("rooturl") + this.active[item]),
+          this.prefs.getCharPref("rooturl") + 'details/' + this.active[item]),
         false);
       image.setAttribute("src","chrome://treestat/content/unknown.png");
       image.setAttribute("maxheight",this.prefs.getIntPref("gemsize"));
@@ -89,7 +89,7 @@ var TreeStatOverlay = {
         if (httpRequest.status >= 200 && httpRequest.status < 300) {
           // Color the gems
           var treestat = JSON.parse(httpRequest.responseText);
-          this.setGemState(treestat);
+          this.setGemState(treestat['result']);
         } else {
           this.setUnknownState(httpRequest.statusText);
         }
@@ -98,7 +98,7 @@ var TreeStatOverlay = {
     // If it takes more than half the refresh time, indicate a problem.
     httpRequest.timeout = 500 * this.prefs.getIntPref("frequency");
     httpRequest.ontimeout = function() { this.setUnknownState("Timeout"); }.bind(this);
-    httpRequest.open('GET',this.prefs.getCharPref("rooturl")+"?format=json");
+    httpRequest.open('GET',this.prefs.getCharPref("rooturl")+"trees");
     httpRequest.send(null);
   },
 

--- a/treestat@roach.at/content/options.js
+++ b/treestat@roach.at/content/options.js
@@ -33,7 +33,7 @@ var TreeStatOptions = {
       var httpRequest = new XMLHttpRequest();
       httpRequest.onreadystatechange = function() {
         if (httpRequest.readyState === 4) {
-          var treestat = JSON.parse(httpRequest.responseText);
+          var treestat = JSON.parse(httpRequest.responseText)['result'];
           var trees = [];
           for (var item in treestat) {
             TreeStatOptions.alltrees.push(item);
@@ -41,7 +41,7 @@ var TreeStatOptions = {
         }
         TreeStatOptions.populateInactive();
       }
-      httpRequest.open('GET',this.prefs.getCharPref("rooturl")+"?format=json");
+      httpRequest.open('GET',this.prefs.getCharPref("rooturl")+"trees");
       httpRequest.send(null);
     } else {
       this.populateInactive();

--- a/treestat@roach.at/defaults/preferences/defaults.js
+++ b/treestat@roach.at/defaults/preferences/defaults.js
@@ -1,4 +1,4 @@
 pref("extensions.treestat.trees", "mozilla-central|mozilla-inbound|try");
-pref("extensions.treestat.rooturl", "https://treestatus.mozilla.org/");
+pref("extensions.treestat.rooturl", "https://api.pub.build.mozilla.org/treestatus/");
 pref("extensions.treestat.frequency", 300);
 pref("extensions.treestat.gemsize", 16);


### PR DESCRIPTION
(untested!)

This updates moz-treestat to hit the new treestatus API being deployed in bug 1181153.  The two big changes are to the URL paths and to the response format, which now includes the result in an object with a 'result' key.

Please don't deploy this until the migration in bug 1181153 is complete.

You can test it against rooturl `https://api-pub-build.allizom.org/treestatus/`.
